### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ This hands-on lab includes the following labs:
 In this lab you will find the prerequisites and steps to help you set up your computer. After completing the lab you will have a working environment ready for the other labs.
 
 #### [Lab 2 - Edge Mode and Feature Detection](edge-mode-and-feature-detection) ####
-#####Working with the browser
+##### Working with the browser
 In this lab you will analyze an existing application and update it to comply with the best practices for Feature Detection. Additionally, you will learn about Edge Mode and its perks.
 
 #### [Lab 3 - Web Development Best Practices](best-practices) ####
-#####Improving what we have
+##### Improving what we have
 In this lab you will take the application from the previous lab and introduce additional best practices to it. You will improve the app styles and remove old-fashioned plugins from it. You will also be introduced to [hand.js](https://handjs.codeplex.com/) and will update the app to leverage its advantages.
 
 #### [Lab 4 - Cross Browser Testing](testing) ####
-#####Making sure everything works
+##### Making sure everything works
 In this lab you will learn about two well-known testing tools: [Remote IE](https://remote.modern.ie/) and [Browser Stack](http://www.browserstack.com/) and test the application with the latter. Additionally, you will learn about Graceful degradation for older browsers and update the app to incorporate fixes for them.
 
 #### [Lab 5 - Mobile First with Responsive Design](mobile-first-design) ####
-#####Taking over other platforms
+##### Taking over other platforms
 In this lab you will continue improving the application, in this case to extend its reach to other platforms. You will discover how the use of Media Queries and other elements can help you provide the users with a better experience for every platform.
 
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -126,7 +126,7 @@ In this task you will use **Hand.js**, a framework for unifying touch, pen and m
 13. Run the application. The signing code will now work in every browser and handle touch correctly.
 
 <a name="Task2" />
-##Working with CSS
+## Working with CSS
 
 In this task you will learn how to apply some CSS best practices. You will first remove inline styles to classes and apply them to similar elements.
 
@@ -529,7 +529,7 @@ In this task you will learn how to apply some CSS best practices. You will first
 1. Test the website in the other browsers. The animation in the home page should behave similarly in all browsers.
 
 <a name="Task3" />
-##Plug-in free Development
+## Plug-in free Development
 
 From the early history of the web, browser plug-ins have played a vital role by enabling rich online multimedia experiences and complex web application functionality. However, along with these capabilities, plug-ins can come with some disadvantages. Because plug-ins are essentially applications that run inside the browser, they consume additional system resources and expose additional attack surface to security risks. Also, plug-ins are not designed for touch, and because they are separate applications from the browser itself, they don't benefit from any changes from the latest browsers that make websites work smoothly with touch. Finally, plug-ins are based on proprietary technologies and are written with variable code quality, making it difficult to predict or control their support across different browsers and operating systems.
 

--- a/edge-mode-and-feature-detection/README.md
+++ b/edge-mode-and-feature-detection/README.md
@@ -10,7 +10,7 @@ This lab includes the following tasks:
 1. [Feature Detection](#Task2)
 
 <a name="Task1" />
-##HTML5 Document Setup
+## HTML5 Document Setup
 
 In this exercise you will learn about the deprecation of legacy Document Modes from Internet Explorer in favor of standard support for HTML5 Document Types in Microsoft Edge.
 
@@ -87,7 +87,7 @@ The first step is to open our colleague's application.
 1. Switch back to Visual Studio and stop debugging.
 
 <a name="Task2" />
-##Feature Detection
+## Feature Detection
 
 _Feature Detection_ is the modern way of building a website that looks and behaves its best in the different browsers and browser versions. It replaces the old error-prone approach of "sniffing" the browser type and version and trying to adjust the code based on that.
 With Feature Detection you are detecting specific features using the availability of native functions and objects in the user's browser.
@@ -150,5 +150,5 @@ In this exercise you will improve the Feature Detection mechanics of the applica
 
 You can find out about other features that can be detected using Modernizr [here](http://modernizr.com/docs/).
 
-###Summary
+### Summary
 In this lab you have learned about standard HTML5 document support in Microsoft Edge and how to use Feature Detection via Modernizr.

--- a/mobile-first-design/README.md
+++ b/mobile-first-design/README.md
@@ -13,7 +13,7 @@ This lab includes the following tasks:
 	4. [Responsive Images](#Task14)
 
 <a name="Task1" />
-##Responsive Design Guidelines##
+## Responsive Design Guidelines ##
 **Mobile First** is a concept created by [Luke Wroblewski](http://www.lukew.com/presos/preso.asp?26) that highlights the need to prioritize the mobile context when creating user experiences. Mobile First allows websites to **reach more people**, forces designers to **focus on core content and functionality**, and lets designers innovate and **take full advantage of new technologies**.
 
 **Responsive web design** responds to the needs of the users and the devices they are using. The layout changes based on the size and capabilities of the device. For example, on a phone, users might see content in a single column view, while a tablet might show the same content in two columns.
@@ -25,7 +25,7 @@ As you may remember, **Contoso Movies**  was developed as a Mobile application, 
 The following sections will describe some of the guidelines to achieve a Responsive design.
 
 <a name="Task11" />
-###**Viewport**###
+### **Viewport** ###
 
 1. Open the **_Layout.cshtml** file located in the **Views/Home** folder.
 
@@ -43,7 +43,7 @@ The following sections will describe some of the guidelines to achieve a Respons
 	> **Note:** Notice that to separate the parameters inside the **content** property, you must use a comma.
 
 <a name="Task12" />
-###**Styles**###
+### **Styles** ###
 
 When writing CSS, you have to keep things lightweight and as fluid as possible. There are lots of devices, and all of them have many different screen sizes. Since screen size is typically unknown, the content should determine how the layout will adjust to its container.
 
@@ -100,7 +100,7 @@ Instead of declaring large screen rules first only to override them for smaller 
 	_The application adapted to smaller screens_
 
 <a name="Task13" />
-###**The tel: URI Scheme**###
+### **The tel: URI Scheme** ###
 
 You should take into account that mobile devices are designed to make phone calls, and some desktop configurations can launch VoIP applications to initiate a phone call. The **tel:** URI scheme includes an easy way for users to facilitate a phone call; you can see an example in the following code.
 
@@ -129,11 +129,11 @@ You should take into account that mobile devices are designed to make phone call
 	_Making a call from the web application_
 
 <a name="Task14" />
-###**Responsive Images**###
+### **Responsive Images** ###
 
 The guideline in this topic is to load mobile optimized images by default, and then conditionally load larger images on demand. There are several different techniques for responsive images, both client-side and server side. Although the Contoso Movies app does not have many large images, some of the approaches are described in the _Cross-Browser testing_ lab.
 
-#Summary#
+# Summary #
 
 Nowadays, to build web applications that covers the most users, it is recommended to use the **Mobile First** design, which means designing your application using mobile as the baseline, and progressively increasing functionality for bigger screen sizes and devices with more capabilities. This concept is referred to as **Progressive Enhancement**.
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -161,7 +161,7 @@ You will now test your website in different browsers using **BrowserStack**. In 
 	As you saw, BrowserStack allows you to test your application in a variety of browsers and devices, be it the latest or an older version. You will learn about supporting older browsers gracefully in the next section, including how to fix the detected issues.
 
 <a name="Task2" />
-##Graceful degradation for older browsers##
+## Graceful degradation for older browsers ##
 When developing for the modern web, it is inevitable that some of the newer properties and effects will not work in older browsers. The strategy of _graceful degradation_ is based on "gracefully" handling older browsers without completely breaking functionality. There are some properties you can leave as is and let the new functionality be available in newer browsers. In other cases, however, the use of newer technologies completely breaks the user experience in older browsers and a workaround must be provided.
 
 Some of these cases are:
@@ -651,5 +651,5 @@ The way to fix it is by providing a "_shiv_" (or _HTML5 Enabling JavaScript_), t
 1. Stop debugging.
 
 
-##Summary##
+## Summary ##
 In this lab you have learned about different ways of testing websites that don't involve a lab with physical machines or devices that you manually interact with. Also, you have seen how to change your website to gracefully support older versions of different browsers.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
